### PR TITLE
shairport: add pkg-config so it can build

### DIFF
--- a/Library/Formula/shairport.rb
+++ b/Library/Formula/shairport.rb
@@ -5,6 +5,7 @@ class Shairport < Formula
   homepage 'https://github.com/albertz/shairport'
 
   depends_on 'libao'
+  depends_on "pkg-config" => :build
 
   def install
     system "mkdir #{bin}"


### PR DESCRIPTION
Note: I tried to PR this from 14a1641f93644ca8c119f70a13ab4cce8b93e5f2 and f0a60e1b5d89785e4fdbf512081c1ffc31bd241e - not sure why the parentage didn't work out.  Trivial change.
